### PR TITLE
Add custom item ability system plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# CustomOre
+# CustomItemSystem
+
+A simple Spigot plugin for Minecraft 1.21.4 that adds a custom item ability system. Players can use `/addability <ability>` while holding an item to attach one of 20 built-in abilities. Using the item will trigger all attached abilities.
+
+This project is a basic example and may require Spigot 1.20.1 API to compile.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>customitemsystem</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/customitemsystem/Ability.java
+++ b/src/main/java/com/example/customitemsystem/Ability.java
@@ -1,0 +1,45 @@
+package com.example.customitemsystem;
+
+import org.bukkit.ChatColor;
+
+public enum Ability {
+    FIREBALL("Fireball"),
+    HEAL("Heal"),
+    SPEED_BOOST("Speed Boost"),
+    INVISIBILITY("Invisibility"),
+    STRENGTH("Strength"),
+    JUMP("Jump"),
+    LIGHTNING("Lightning"),
+    TELEPORT("Teleport"),
+    EXPLOSION("Explosion"),
+    FLIGHT("Flight"),
+    WATER_BREATHING("Water Breathing"),
+    RESISTANCE("Resistance"),
+    HASTE("Haste"),
+    REGENERATION("Regeneration"),
+    NIGHT_VISION("Night Vision"),
+    FIRE_RESISTANCE("Fire Resistance"),
+    LUCK("Luck"),
+    GLOWING("Glowing"),
+    POISON_CLOUD("Poison Cloud"),
+    SLOWNESS_AREA("Slowness Area");
+
+    private final String displayName;
+
+    Ability(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return ChatColor.GREEN + displayName;
+    }
+
+    public static Ability fromString(String name) {
+        for (Ability a : values()) {
+            if (a.name().equalsIgnoreCase(name)) {
+                return a;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/customitemsystem/AbilityManager.java
+++ b/src/main/java/com/example/customitemsystem/AbilityManager.java
@@ -1,0 +1,100 @@
+package com.example.customitemsystem;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AbilityManager implements Listener {
+
+    private final NamespacedKey key;
+    private final JavaPlugin plugin;
+
+    public AbilityManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.key = new NamespacedKey(plugin, "abilities");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void addAbility(ItemStack item, Ability ability) {
+        if (item == null || item.getType() == Material.AIR) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        List<String> list = getAbilities(meta);
+        if (!list.contains(ability.name())) {
+            list.add(ability.name());
+            container.set(key, PersistentDataType.STRING, String.join(",", list));
+            List<String> lore = meta.getLore();
+            if (lore == null) lore = new ArrayList<>();
+            lore.add(ability.getDisplayName());
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+    }
+
+    public List<String> getAbilities(ItemMeta meta) {
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        String data = container.get(key, PersistentDataType.STRING);
+        List<String> list = new ArrayList<>();
+        if (data != null && !data.isEmpty()) {
+            for (String s : data.split(",")) {
+                list.add(s);
+            }
+        }
+        return list;
+    }
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        ItemStack item = event.getItem();
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> abilities = getAbilities(meta);
+        if (abilities.isEmpty()) return;
+        Player player = event.getPlayer();
+        for (String ab : abilities) {
+            Ability ability = Ability.fromString(ab);
+            if (ability != null) {
+                applyAbility(player, ability);
+            }
+        }
+    }
+
+    private void applyAbility(Player player, Ability ability) {
+        switch (ability) {
+            case FIREBALL -> player.launchProjectile(org.bukkit.entity.Fireball.class);
+            case HEAL -> player.setHealth(Math.min(player.getMaxHealth(), player.getHealth() + 4));
+            case SPEED_BOOST -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SPEED, 200, 1));
+            case INVISIBILITY -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY, 200, 0));
+            case STRENGTH -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.INCREASE_DAMAGE, 200, 1));
+            case JUMP -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.JUMP, 200, 2));
+            case LIGHTNING -> player.getWorld().strikeLightning(player.getTargetBlockExact(50).getLocation());
+            case TELEPORT -> player.teleport(player.getLocation().add(player.getLocation().getDirection().multiply(5)));
+            case EXPLOSION -> player.getWorld().createExplosion(player.getLocation(), 2F, false, false);
+            case FLIGHT -> player.setAllowFlight(true);
+            case WATER_BREATHING -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.WATER_BREATHING, 600, 0));
+            case RESISTANCE -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.DAMAGE_RESISTANCE, 200, 1));
+            case HASTE -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.FAST_DIGGING, 200, 1));
+            case REGENERATION -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.REGENERATION, 200, 1));
+            case NIGHT_VISION -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.NIGHT_VISION, 400, 0));
+            case FIRE_RESISTANCE -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.FIRE_RESISTANCE, 600, 0));
+            case LUCK -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.LUCK, 600, 0));
+            case GLOWING -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.GLOWING, 200, 0));
+            case POISON_CLOUD -> player.getWorld().spawnParticle(org.bukkit.Particle.SPELL_MOB, player.getLocation(), 20, 0.5, 0.5, 0.5, 1);
+            case SLOWNESS_AREA -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SLOW, 200, 1));
+        }
+    }
+}

--- a/src/main/java/com/example/customitemsystem/CustomItemPlugin.java
+++ b/src/main/java/com/example/customitemsystem/CustomItemPlugin.java
@@ -1,0 +1,41 @@
+package com.example.customitemsystem;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class CustomItemPlugin extends JavaPlugin {
+
+    private AbilityManager abilityManager;
+
+    @Override
+    public void onEnable() {
+        abilityManager = new AbilityManager(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (command.getName().equalsIgnoreCase("addability")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("Only players can use this command.");
+                return true;
+            }
+            if (args.length != 1) {
+                sender.sendMessage("Usage: /" + label + " <ability>");
+                return true;
+            }
+            Ability ability = Ability.fromString(args[0]);
+            if (ability == null) {
+                sender.sendMessage("Unknown ability.");
+                return true;
+            }
+            ItemStack item = player.getInventory().getItemInMainHand();
+            abilityManager.addAbility(item, ability);
+            sender.sendMessage("Added ability " + ability.name() + " to item.");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: CustomItemSystem
+main: com.example.customitemsystem.CustomItemPlugin
+version: 1.0
+api-version: 1.20
+commands:
+  addability:
+    description: Add an ability to the item in your hand.
+    usage: /<command> <ability>


### PR DESCRIPTION
## Summary
- add Spigot plugin skeleton with custom item abilities
- support `/addability <ability>` command
- implement 20 example abilities

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fec105f388329837bf010a82dc759