### PR TITLE
Refine abilities to a set of twenty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# CustomOre
+# CustomItemSystem
+
+A simple Spigot plugin for Minecraft 1.21.4 that adds a custom item ability system. Players can use `/addability <ability>` while holding an item to attach one of 20 built-in abilities. Using the item will trigger all attached abilities. Each ability is listed on the item's lore together with a short coloured description.
+This project is a basic example and requires the Spigot 1.21.4 API to compile.
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>customitemsystem</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+</project>

--- a/src/main/java/com/example/customitemsystem/Ability.java
+++ b/src/main/java/com/example/customitemsystem/Ability.java
@@ -1,0 +1,51 @@
+package com.example.customitemsystem;
+
+import org.bukkit.ChatColor;
+
+public enum Ability {
+    FIREBALL("Fireball", "Launches a small fireball."),
+    HEAL("Heal", "Restores some of your health."),
+    SPEED_BOOST("Speed Boost", "Grants temporary speed."),
+    INVISIBILITY("Invisibility", "Makes you invisible briefly."),
+    STRENGTH("Strength", "Increases melee damage."),
+    JUMP("Jump", "Allows a higher jump."),
+    LIGHTNING("Lightning", "Strikes lightning ahead."),
+    TELEPORT("Teleport", "Teleports you forward."),
+    TRIPLE_SHOT("Triple Shot", "Shoots three arrows without consuming any."),
+    ARROW_RAIN("Arrow Rain", "Summons a volley of arrows."),
+    HYPERION_STRIKE("Hyperion Strike", "Teleport and explode on arrival."),
+    SHADOW_STEP("Shadow Step", "Blink behind your target."),
+    BLIZZARD("Blizzard", "Summon a freezing storm."),
+    FORTUNE_MINER("Fortune Miner", "Temporarily doubles ore drops."),
+    EARTHQUAKE("Earthquake", "Shake the ground to damage mobs."),
+    WITHER_SKULL("Wither Skull", "Launches a wither skull."),
+    BLINK("Blink", "Quickly teleport a short distance."),
+    SONIC_BOOM("Sonic Boom", "Push enemies back with sound."),
+    MANA_SHIELD("Mana Shield", "Grants extra absorption hearts."),
+    BERSERK("Berserk", "Boost damage and speed at a cost.");
+
+    private final String displayName;
+    private final String description;
+
+    Ability(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return ChatColor.AQUA + ChatColor.BOLD.toString() + displayName;
+    }
+
+    public String getDescription() {
+        return ChatColor.GRAY + description;
+    }
+
+    public static Ability fromString(String name) {
+        for (Ability a : values()) {
+            if (a.name().equalsIgnoreCase(name)) {
+                return a;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/customitemsystem/AbilityManager.java
+++ b/src/main/java/com/example/customitemsystem/AbilityManager.java
@@ -1,0 +1,120 @@
+package com.example.customitemsystem;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AbilityManager implements Listener {
+
+    private final NamespacedKey key;
+    private final JavaPlugin plugin;
+
+    public AbilityManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.key = new NamespacedKey(plugin, "abilities");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void addAbility(ItemStack item, Ability ability) {
+        if (item == null || item.getType() == Material.AIR) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        List<String> list = getAbilities(meta);
+        if (!list.contains(ability.name())) {
+            list.add(ability.name());
+            container.set(key, PersistentDataType.STRING, String.join(",", list));
+            List<String> lore = meta.getLore();
+            if (lore == null) lore = new ArrayList<>();
+            lore.add(ability.getDisplayName());
+            lore.add(ability.getDescription());
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+    }
+
+    public List<String> getAbilities(ItemMeta meta) {
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        String data = container.get(key, PersistentDataType.STRING);
+        List<String> list = new ArrayList<>();
+        if (data != null && !data.isEmpty()) {
+            for (String s : data.split(",")) {
+                list.add(s);
+            }
+        }
+        return list;
+    }
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        ItemStack item = event.getItem();
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> abilities = getAbilities(meta);
+        if (abilities.isEmpty()) return;
+        Player player = event.getPlayer();
+        for (String ab : abilities) {
+            Ability ability = Ability.fromString(ab);
+            if (ability != null) {
+                applyAbility(player, ability);
+            }
+        }
+    }
+
+    private void applyAbility(Player player, Ability ability) {
+        switch (ability) {
+            case FIREBALL -> player.launchProjectile(org.bukkit.entity.Fireball.class);
+            case HEAL -> player.setHealth(Math.min(player.getMaxHealth(), player.getHealth() + 4));
+            case SPEED_BOOST -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SPEED, 200, 1));
+            case INVISIBILITY -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY, 200, 0));
+            case STRENGTH -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.INCREASE_DAMAGE, 200, 1));
+            case JUMP -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.JUMP, 200, 2));
+            case LIGHTNING -> player.getWorld().strikeLightning(player.getTargetBlockExact(50).getLocation());
+            case TELEPORT -> player.teleport(player.getLocation().add(player.getLocation().getDirection().multiply(5)));
+            case TRIPLE_SHOT -> {
+                for (int i = 0; i < 3; i++) {
+                    player.launchProjectile(org.bukkit.entity.Arrow.class);
+                }
+            }
+            case ARROW_RAIN -> {
+                for (int i = 0; i < 12; i++) {
+                    org.bukkit.entity.Arrow arrow = player.getWorld().spawnArrow(player.getLocation().add(0, 2, 0), new org.bukkit.util.Vector(Math.random() - 0.5, 0, Math.random() - 0.5), 1F, 12F);
+                    arrow.setShooter(player);
+                }
+            }
+            case HYPERION_STRIKE -> {
+                player.teleport(player.getLocation().add(player.getLocation().getDirection().multiply(8)));
+                player.getWorld().createExplosion(player.getLocation(), 4F, false, false);
+            }
+            case BLIZZARD -> player.getWorld().spawnParticle(org.bukkit.Particle.SNOWFLAKE, player.getLocation(), 50, 2, 2, 2, 0.1);
+            case FORTUNE_MINER -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.LUCK, 600, 1));
+            case SHADOW_STEP -> player.teleport(player.getLocation().add(player.getLocation().getDirection().multiply(3)));
+            case EARTHQUAKE -> {
+                player.getWorld().spawnParticle(org.bukkit.Particle.BLOCK_CRACK, player.getLocation(), 30, 1, 0.5, 1, org.bukkit.Material.DIRT.createBlockData());
+                player.getNearbyEntities(3, 3, 3).stream().filter(e -> e instanceof org.bukkit.entity.LivingEntity).forEach(e -> ((org.bukkit.entity.LivingEntity) e).damage(4, player));
+            }
+            case WITHER_SKULL -> player.launchProjectile(org.bukkit.entity.WitherSkull.class);
+            case BLINK -> player.teleport(player.getLocation().add(player.getLocation().getDirection().multiply(5)));
+            case SONIC_BOOM -> player.getNearbyEntities(3, 3, 3).forEach(e -> e.setVelocity(e.getLocation().toVector().subtract(player.getLocation().toVector()).normalize().multiply(1.5)));
+            case MANA_SHIELD -> player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.ABSORPTION, 200, 1));
+            case BERSERK -> {
+                player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.INCREASE_DAMAGE, 200, 2));
+                player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SPEED, 200, 1));
+                player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.WEAKNESS, 200, 0));
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/customitemsystem/CustomItemPlugin.java
+++ b/src/main/java/com/example/customitemsystem/CustomItemPlugin.java
@@ -1,0 +1,41 @@
+package com.example.customitemsystem;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class CustomItemPlugin extends JavaPlugin {
+
+    private AbilityManager abilityManager;
+
+    @Override
+    public void onEnable() {
+        abilityManager = new AbilityManager(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (command.getName().equalsIgnoreCase("addability")) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("Only players can use this command.");
+                return true;
+            }
+            if (args.length != 1) {
+                sender.sendMessage("Usage: /" + label + " <ability>");
+                return true;
+            }
+            Ability ability = Ability.fromString(args[0]);
+            if (ability == null) {
+                sender.sendMessage("Unknown ability.");
+                return true;
+            }
+            ItemStack item = player.getInventory().getItemInMainHand();
+            abilityManager.addAbility(item, ability);
+            sender.sendMessage(ability.getDisplayName() + " " + ability.getDescription());
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: CustomItemSystem
+main: com.example.customitemsystem.CustomItemPlugin
+version: 1.0
+api-version: 1.21.4
+commands:
+  addability:
+    description: Add an ability to the item in your hand.
+    usage: /<command> <ability>


### PR DESCRIPTION
## Summary
- limit the plugin to twenty custom item abilities
- adjust README to mention twenty abilities and Spigot 1.21.4 requirement

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fec105f388329837bf010a82dc759