### PR TITLE
Add persistent auction house and improved morph set

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@
 * Each ability has a mana cost. Players regenerate mana over time and the current amount is shown in the action bar. !!! Works !!!
 * Items display each ability and its description in the lore. !!! Works !!!
 * Improved slayer bosses with a boss bar showing kill progress and boss health. Slayer bosses gain extra attacks as tiers increase. !!! Works but wip
-* `/armor` opens a paged menu with ten themed armor sets from Hypixel and Wynncraft. !!!! ARMOR ABILITYS DO NOT YET WORK ON ATTACKING ENEMIES !!!!
-* `/ah` and `/ahsell` provide a basic but safer auction house where items can be listed and purchased. !!!! DO NOT USE !!! will be fixed next update
+* `/armor` now opens a wardrobe that stores up to 18 armor sets per player. Shift-click a slot to save your current gear and click to equip with a short cooldown.
+* `/ah` and `/ahsell <price>` implement a simple buy-it-now auction house with a 5 % listing fee and duplicate item protection. Listings are saved to `plugins/CustomItemSystem/save/auctionhouse.yml` so they persist after restarts.
+* Morph armor pieces now display their full set bonuses in the lore and show how many pieces you currently have equipped along with the next bonus threshold.

--- a/src/main/java/com/example/customitemsystem/AuctionHouse.java
+++ b/src/main/java/com/example/customitemsystem/AuctionHouse.java
@@ -1,39 +1,118 @@
 package com.example.customitemsystem;
 
+import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.ConfigurationSection;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * Very small auction house that allows players to list and buy items.
+ * Simple auction house supporting buy-it-now listings with a listing fee.
  */
 public class AuctionHouse implements Listener {
     private final JavaPlugin plugin;
-    private final List<ItemStack> listings = new ArrayList<>();
+    private final Map<Integer, Listing> listings = new HashMap<>();
+    private int nextId = 1;
+    private final NamespacedKey idKey;
+    private final File saveFile;
 
     public AuctionHouse(JavaPlugin plugin) {
         this.plugin = plugin;
+        this.idKey = new NamespacedKey(plugin, "item_id");
         Bukkit.getPluginManager().registerEvents(this, plugin);
+        File dir = new File(plugin.getDataFolder(), "save");
+        if (!dir.exists()) dir.mkdirs();
+        this.saveFile = new File(dir, "auctionhouse.yml");
+        loadData();
+    }
+
+    /** Load listings from disk. */
+    private void loadData() {
+        if (!saveFile.exists()) return;
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(saveFile);
+        nextId = config.getInt("nextId", 1);
+        ConfigurationSection sec = config.getConfigurationSection("listings");
+        if (sec != null) {
+            for (String key : sec.getKeys(false)) {
+                int id = Integer.parseInt(key);
+                ItemStack item = sec.getItemStack(key + ".item");
+                if (item == null) continue;
+                Listing l = new Listing();
+                l.id = id;
+                l.item = item;
+                l.itemId = sec.getString(key + ".itemId");
+                l.seller = UUID.fromString(sec.getString(key + ".seller"));
+                l.price = sec.getDouble(key + ".price");
+                l.endTime = sec.getLong(key + ".endTime");
+                listings.put(id, l);
+            }
+        }
+    }
+
+    /** Save listings to disk. */
+    public void saveData() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("nextId", nextId);
+        for (Listing l : listings.values()) {
+            String key = "listings." + l.id;
+            config.set(key + ".item", l.item);
+            config.set(key + ".itemId", l.itemId);
+            config.set(key + ".seller", l.seller.toString());
+            config.set(key + ".price", l.price);
+            config.set(key + ".endTime", l.endTime);
+        }
+        try {
+            config.save(saveFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void assignId(ItemStack item) {
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (!container.has(idKey, PersistentDataType.STRING)) {
+            container.set(idKey, PersistentDataType.STRING, UUID.randomUUID().toString());
+            item.setItemMeta(meta);
+        }
     }
 
     public void open(Player player, int page) {
         Inventory inv = Bukkit.createInventory(player, 54, ChatColor.GOLD + "Auction House");
+        List<Listing> sorted = new ArrayList<>(listings.values());
+        sorted.sort(Comparator.comparingInt(l -> l.id));
         int start = page * 45;
-        int end = Math.min(start + 45, listings.size());
-        for (int i = start; i < end; i++) {
-            inv.addItem(listings.get(i));
+        for (int i = 0; i < 45 && start + i < sorted.size(); i++) {
+            Listing l = sorted.get(start + i);
+            ItemStack display = l.item.clone();
+            ItemMeta meta = display.getItemMeta();
+            if (meta != null) {
+                List<String> lore = meta.getLore() == null ? new ArrayList<>() : new ArrayList<>(meta.getLore());
+                lore.add("");
+                lore.add("");
+                lore.add(ChatColor.YELLOW + "Price: " + l.price);
+                lore.add(ChatColor.GRAY + "Seller: " + Bukkit.getOfflinePlayer(l.seller).getName());
+                meta.setLore(lore);
+                display.setItemMeta(meta);
+            }
+            inv.setItem(i, display);
         }
         ItemStack prev = new ItemStack(Material.ARROW);
         ItemMeta m = prev.getItemMeta();
@@ -41,44 +120,85 @@ public class AuctionHouse implements Listener {
         ItemStack next = new ItemStack(Material.ARROW);
         m = next.getItemMeta();
         if (m != null) { m.setDisplayName(ChatColor.YELLOW + "Next Page"); next.setItemMeta(m); }
-        inv.setItem(45, prev); inv.setItem(53, next);
+        inv.setItem(45, prev);
+        inv.setItem(53, next);
         player.openInventory(inv);
-        player.getPersistentDataContainer().set(new org.bukkit.NamespacedKey(plugin, "ah_page"), org.bukkit.persistence.PersistentDataType.INTEGER, page);
+        player.getPersistentDataContainer().set(new NamespacedKey(plugin, "ah_page"), PersistentDataType.INTEGER, page);
     }
 
-    public void listItem(Player player, ItemStack item) {
+    public void listItem(Player player, ItemStack item, double price) {
         if (item == null || item.getType() == Material.AIR) return;
-        listings.add(item.clone());
+        assignId(item);
+        String id = item.getItemMeta().getPersistentDataContainer().get(idKey, PersistentDataType.STRING);
+        for (Listing l : listings.values()) {
+            if (l.itemId.equals(id)) {
+                player.sendMessage(ChatColor.RED + "This item is already listed.");
+                return;
+            }
+        }
+        int fee = (int) Math.ceil(price * 0.05);
+        if (player.getLevel() < fee) {
+            player.sendMessage(ChatColor.RED + "You need " + fee + " experience levels to list this item.");
+            return;
+        }
+        player.setLevel(player.getLevel() - fee);
+        ItemStack clone = item.clone();
         player.getInventory().removeItem(item);
-        player.sendMessage(ChatColor.GREEN + "Item listed in the auction house.");
+        Listing l = new Listing();
+        l.id = nextId++;
+        l.item = clone;
+        l.itemId = id;
+        l.seller = player.getUniqueId();
+        l.price = price;
+        l.endTime = System.currentTimeMillis() + 3600_000; // 1h
+        listings.put(l.id, l);
+        player.sendMessage(ChatColor.GREEN + "Item listed for " + price + " (fee " + fee + ")");
     }
 
     @EventHandler
     public void onClick(InventoryClickEvent e) {
-        if (e.getView().getTitle().equals(ChatColor.GOLD + "Auction House")) {
-            e.setCancelled(true);
-            ItemStack item = e.getCurrentItem();
-            if (item == null) return;
-            Player player = (Player) e.getWhoClicked();
-            int page = player.getPersistentDataContainer().getOrDefault(new org.bukkit.NamespacedKey(plugin, "ah_page"), org.bukkit.persistence.PersistentDataType.INTEGER, 0);
-            if (item.getType() == Material.ARROW) {
-                if (e.getSlot() == 45 && page > 0) {
-                    open(player, page - 1);
-                } else if (e.getSlot() == 53 && (page + 1) * 45 < listings.size()) {
-                    open(player, page + 1);
-                }
-                return;
+        if (!(ChatColor.GOLD + "Auction House").equals(e.getView().getTitle())) return;
+        e.setCancelled(true);
+        Player player = (Player) e.getWhoClicked();
+        ItemStack item = e.getCurrentItem();
+        if (item == null) return;
+        int page = player.getPersistentDataContainer().getOrDefault(new NamespacedKey(plugin, "ah_page"), PersistentDataType.INTEGER, 0);
+        if (item.getType() == Material.ARROW) {
+            if (e.getSlot() == 45 && page > 0) {
+                open(player, page - 1);
+            } else if (e.getSlot() == 53 && (page + 1) * 45 < listings.size()) {
+                open(player, page + 1);
             }
-            listings.remove(item);
-            player.getInventory().addItem(item);
-            player.sendMessage(ChatColor.GREEN + "Purchased item from auction house.");
+            return;
         }
+        Listing target = null;
+        for (Listing l : listings.values()) {
+            if (l.item.isSimilar(item)) { target = l; break; }
+        }
+        if (target == null) return;
+        if (player.getUniqueId().equals(target.seller)) {
+            player.sendMessage(ChatColor.RED + "You cannot buy your own item.");
+            return;
+        }
+        if (player.getLevel() < (int) target.price) {
+            player.sendMessage(ChatColor.RED + "Not enough experience levels.");
+            return;
+        }
+        player.setLevel(player.getLevel() - (int) target.price);
+        player.getInventory().addItem(target.item);
+        listings.remove(target.id);
+        player.sendMessage(ChatColor.GREEN + "Purchased item for " + target.price);
+        Player seller = Bukkit.getPlayer(target.seller);
+        if (seller != null) seller.sendMessage(ChatColor.GREEN + player.getName() + " bought your item for " + target.price);
+        open(player, page);
     }
 
-    @EventHandler
-    public void onClose(InventoryCloseEvent e) {
-        if (e.getView().getTitle().equals(ChatColor.GOLD + "Auction House")) {
-            // nothing to do - inventory view is read-only
-        }
+    private static class Listing {
+        int id;
+        ItemStack item;
+        String itemId;
+        UUID seller;
+        double price;
+        long endTime;
     }
 }

--- a/src/main/java/com/example/customitemsystem/CustomItemPlugin.java
+++ b/src/main/java/com/example/customitemsystem/CustomItemPlugin.java
@@ -5,9 +5,10 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.ChatColor;
 
 import com.example.customitemsystem.slayer.SlayerManager;
-import com.example.customitemsystem.ArmorMenu;
+import com.example.customitemsystem.wardrobe.WardrobeManager;
 import com.example.customitemsystem.AuctionHouse;
 import com.example.customitemsystem.ManaManager;
 
@@ -16,16 +17,25 @@ public class CustomItemPlugin extends JavaPlugin {
     private AbilityManager abilityManager;
     private SlayerManager slayerManager;
     private ManaManager manaManager;
-    private ArmorMenu armorMenu;
+    private WardrobeManager wardrobeManager;
     private AuctionHouse auctionHouse;
+    private com.example.customitemsystem.morph.MorphSetManager morphManager;
 
     @Override
     public void onEnable() {
         manaManager = new ManaManager(this);
         abilityManager = new AbilityManager(this, manaManager);
         slayerManager = new SlayerManager(this);
-        armorMenu = new ArmorMenu(this, abilityManager);
+        wardrobeManager = new WardrobeManager(this);
         auctionHouse = new AuctionHouse(this);
+        morphManager = new com.example.customitemsystem.morph.MorphSetManager(this);
+    }
+
+    @Override
+    public void onDisable() {
+        if (auctionHouse != null) {
+            auctionHouse.saveData();
+        }
     }
 
     @Override
@@ -57,7 +67,7 @@ public class CustomItemPlugin extends JavaPlugin {
             return true;
         } else if (command.getName().equalsIgnoreCase("armor")) {
             if (!(sender instanceof Player player)) return true;
-            armorMenu.open(player, 0);
+            wardrobeManager.open(player);
             return true;
         } else if (command.getName().equalsIgnoreCase("ah")) {
             if (!(sender instanceof Player player)) return true;
@@ -65,8 +75,42 @@ public class CustomItemPlugin extends JavaPlugin {
             return true;
         } else if (command.getName().equalsIgnoreCase("ahsell")) {
             if (!(sender instanceof Player player)) return true;
+            if (args.length != 1) {
+                player.sendMessage("Usage: /ahsell <price>");
+                return true;
+            }
+            double price;
+            try { price = Double.parseDouble(args[0]); } catch (NumberFormatException ex) { player.sendMessage("Invalid price"); return true; }
             ItemStack item = player.getInventory().getItemInMainHand();
-            auctionHouse.listItem(player, item);
+            auctionHouse.listItem(player, item, price);
+            return true;
+        } else if (command.getName().equalsIgnoreCase("givemorph")) {
+            if (!(sender instanceof Player player)) return true;
+            for (com.example.customitemsystem.morph.MorphItem item : com.example.customitemsystem.morph.MorphItem.values()) {
+                ItemStack stack = new ItemStack(item.getMaterial());
+                org.bukkit.inventory.meta.ItemMeta meta = stack.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(item.getDisplayName());
+                    java.util.List<String> lore = new java.util.ArrayList<>();
+                    lore.add(ChatColor.GRAY + "Requires Level " + item.getLevelReq());
+                    lore.add("");
+                    lore.add(ChatColor.LIGHT_PURPLE + "Morph Set Bonuses:");
+                    lore.add(ChatColor.AQUA + "+5 All Skills");
+                    lore.add(ChatColor.AQUA + "+8 Mana Regeneration /5s");
+                    lore.add(ChatColor.AQUA + "+20% Walk Speed");
+                    lore.add(ChatColor.AQUA + "+260 Health Regeneration");
+                    lore.add(ChatColor.AQUA + "+182 Spell Damage");
+                    lore.add(ChatColor.AQUA + "+176 Melee Damage");
+                    lore.add("");
+                    lore.add(ChatColor.GREEN + "Pieces: 0/" + com.example.customitemsystem.morph.MorphItem.values().length);
+                    lore.add(ChatColor.GRAY + "Next bonus at 2 pieces");
+                    meta.setLore(lore);
+                    stack.setItemMeta(meta);
+                }
+                player.getInventory().addItem(stack);
+            }
+            morphManager.refreshPlayer(player);
+            player.sendMessage(ChatColor.GREEN + "Given Morph set items.");
             return true;
         }
         return false;

--- a/src/main/java/com/example/customitemsystem/ManaManager.java
+++ b/src/main/java/com/example/customitemsystem/ManaManager.java
@@ -3,6 +3,8 @@ package com.example.customitemsystem;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -34,7 +36,8 @@ public class ManaManager implements Listener {
             if (p == null) continue;
             int value = Math.min(maxMana, mana.get(id) + 1);
             mana.put(id, value);
-            p.sendActionBar(ChatColor.AQUA + "Mana: " + value + "/" + maxMana);
+            p.spigot().sendMessage(ChatMessageType.ACTION_BAR,
+                new TextComponent(ChatColor.AQUA + "Mana: " + value + "/" + maxMana));
         }
     }
 

--- a/src/main/java/com/example/customitemsystem/morph/MorphItem.java
+++ b/src/main/java/com/example/customitemsystem/morph/MorphItem.java
@@ -1,0 +1,52 @@
+package com.example.customitemsystem.morph;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+
+/**
+ * Enum representing the pieces of the Morph set with level requirements.
+ */
+public enum MorphItem {
+    MORPH_STARDUST("Morph-Stardust", Material.DIAMOND_HELMET, 100),
+    MORPH_STEEL("Morph-Steel", Material.DIAMOND_CHESTPLATE, 75),
+    MORPH_IRON("Morph-Iron", Material.DIAMOND_LEGGINGS, 50),
+    MORPH_GOLD("Morph-Gold", Material.DIAMOND_BOOTS, 30),
+    MORPH_TOPAZ("Morph-Topaz", Material.GOLD_NUGGET, 20),
+    MORPH_EMERALD("Morph-Emerald", Material.EMERALD, 20),
+    MORPH_AMETHYST("Morph-Amethyst", Material.AMETHYST_SHARD, 20),
+    MORPH_RUBY("Morph-Ruby", Material.REDSTONE, 20);
+
+    private final String displayName;
+    private final Material material;
+    private final int levelReq;
+
+    MorphItem(String displayName, Material material, int levelReq) {
+        this.displayName = displayName;
+        this.material = material;
+        this.levelReq = levelReq;
+    }
+
+    public String getDisplayName() {
+        return ChatColor.LIGHT_PURPLE + displayName;
+    }
+
+    public Material getMaterial() {
+        return material;
+    }
+
+    public int getLevelReq() {
+        return levelReq;
+    }
+
+    /**
+     * Returns the Morph item for the given material or null if none matches.
+     */
+    public static MorphItem fromMaterial(Material material) {
+        for (MorphItem item : values()) {
+            if (item.material == material) {
+                return item;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/customitemsystem/morph/MorphSetManager.java
+++ b/src/main/java/com/example/customitemsystem/morph/MorphSetManager.java
@@ -1,0 +1,132 @@
+package com.example.customitemsystem.morph;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Applies bonuses for players wearing Morph set items.
+ */
+public class MorphSetManager implements Listener {
+    private final JavaPlugin plugin;
+
+    public MorphSetManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+        Bukkit.getScheduler().runTaskTimer(plugin, this::tick, 0L, 100L);
+    }
+
+    private void tick() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            int pieces = countPieces(player);
+            if (pieces == MorphItem.values().length) {
+                applyFullSet(player);
+            }
+            updateLore(player, pieces);
+        }
+    }
+
+    private void updateLore(Player player, int pieces) {
+        for (ItemStack item : player.getInventory().getArmorContents()) {
+            refreshItemLore(item, pieces);
+        }
+        for (ItemStack item : player.getInventory().getContents()) {
+            refreshItemLore(item, pieces);
+        }
+    }
+
+    /** Updates Morph item lore for the given player immediately. */
+    public void refreshPlayer(Player player) {
+        updateLore(player, countPieces(player));
+    }
+
+    private void refreshItemLore(ItemStack item, int pieces) {
+        if (item == null) return;
+        MorphItem morph = MorphItem.fromMaterial(item.getType());
+        if (morph == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        List<String> lore = new ArrayList<>();
+        lore.add(ChatColor.GRAY + "Requires Level " + morph.getLevelReq());
+        lore.add("");
+        lore.add(ChatColor.LIGHT_PURPLE + "Morph Set Bonuses:");
+        lore.add(ChatColor.AQUA + "+5 All Skills");
+        lore.add(ChatColor.AQUA + "+8 Mana Regeneration /5s");
+        lore.add(ChatColor.AQUA + "+20% Walk Speed");
+        lore.add(ChatColor.AQUA + "+260 Health Regeneration");
+        lore.add(ChatColor.AQUA + "+182 Spell Damage");
+        lore.add(ChatColor.AQUA + "+176 Melee Damage");
+        lore.add("");
+        lore.add(ChatColor.GREEN + "Pieces: " + pieces + "/" + MorphItem.values().length);
+        int next = nextThreshold(pieces);
+        if (next > pieces) {
+            lore.add(ChatColor.GRAY + "Next bonus at " + next + " pieces");
+        } else {
+            lore.add(ChatColor.GRAY + "All bonuses unlocked");
+        }
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+    }
+
+    private int nextThreshold(int pieces) {
+        int[] t = {2,4,6,8};
+        for (int x : t) {
+            if (pieces < x) return x;
+        }
+        return 8;
+    }
+
+    private int countPieces(Player player) {
+        int count = 0;
+        ItemStack[] armor = player.getInventory().getArmorContents();
+        if (armor[3] != null && armor[3].getType() == MorphItem.MORPH_STARDUST.getMaterial()) count++;
+        if (armor[2] != null && armor[2].getType() == MorphItem.MORPH_STEEL.getMaterial()) count++;
+        if (armor[1] != null && armor[1].getType() == MorphItem.MORPH_IRON.getMaterial()) count++;
+        if (armor[0] != null && armor[0].getType() == MorphItem.MORPH_GOLD.getMaterial()) count++;
+        Set<Material> acc = EnumSet.noneOf(Material.class);
+        acc.add(MorphItem.MORPH_TOPAZ.getMaterial());
+        acc.add(MorphItem.MORPH_EMERALD.getMaterial());
+        acc.add(MorphItem.MORPH_AMETHYST.getMaterial());
+        acc.add(MorphItem.MORPH_RUBY.getMaterial());
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null) continue;
+            if (acc.remove(item.getType())) count++;
+        }
+        return count;
+    }
+
+    private void applyFullSet(Player player) {
+        player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.REGENERATION, 120, 2));
+        player.addPotionEffect(new org.bukkit.potion.PotionEffect(org.bukkit.potion.PotionEffectType.SPEED, 120, 1));
+        player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE).setBaseValue( player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE).getBaseValue() + 4);
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        event.getPlayer().sendMessage(ChatColor.LIGHT_PURPLE + "Morph set bonuses active when all pieces are equipped.");
+    }
+
+    // Example bonus: extra damage when attacking while full set is equipped
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (event.getDamager() instanceof Player player) {
+            if (countPieces(player) == MorphItem.values().length) {
+                event.setDamage(event.getDamage() + 5);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/customitemsystem/wardrobe/WardrobeManager.java
+++ b/src/main/java/com/example/customitemsystem/wardrobe/WardrobeManager.java
@@ -1,0 +1,124 @@
+package com.example.customitemsystem.wardrobe;
+
+import java.util.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Basic wardrobe system allowing players to store and equip armor sets.
+ */
+public class WardrobeManager implements Listener {
+    private final JavaPlugin plugin;
+    private final Map<UUID, List<SetSlot>> sets = new HashMap<>();
+    private final Map<UUID, Long> lastSwitch = new HashMap<>();
+    private final NamespacedKey idKey;
+
+    public WardrobeManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.idKey = new NamespacedKey(plugin, "item_id");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    private List<SetSlot> getSlots(Player player) {
+        return sets.computeIfAbsent(player.getUniqueId(), k -> {
+            List<SetSlot> list = new ArrayList<>();
+            for (int i = 0; i < 18; i++) list.add(new SetSlot("Set " + (i + 1)));
+            return list;
+        });
+    }
+
+    public void open(Player player) {
+        Inventory inv = Bukkit.createInventory(player, 27, ChatColor.BLUE + "Wardrobe");
+        List<SetSlot> list = getSlots(player);
+        for (int i = 0; i < 18; i++) {
+            SetSlot slot = list.get(i);
+            ItemStack display = new ItemStack(Material.LEATHER_CHESTPLATE);
+            ItemMeta meta = display.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName(ChatColor.AQUA + slot.name);
+                List<String> lore = new ArrayList<>();
+                lore.add(ChatColor.YELLOW + "Left click: equip");
+                lore.add(ChatColor.YELLOW + "Shift + click: save current");
+                meta.setLore(lore);
+                display.setItemMeta(meta);
+            }
+            inv.setItem(i, display);
+        }
+        player.openInventory(inv);
+    }
+
+    private void assignId(ItemStack item) {
+        if (item == null) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (!container.has(idKey, PersistentDataType.STRING)) {
+            container.set(idKey, PersistentDataType.STRING, UUID.randomUUID().toString());
+            item.setItemMeta(meta);
+        }
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        if (!ChatColor.BLUE + "Wardrobe".equals(e.getView().getTitle())) return;
+        e.setCancelled(true);
+        Player player = (Player) e.getWhoClicked();
+        int slot = e.getRawSlot();
+        if (slot < 0 || slot >= 18) return;
+        List<SetSlot> list = getSlots(player);
+        SetSlot set = list.get(slot);
+        if (e.isShiftClick()) {
+            // save current armor
+            ItemStack[] armor = player.getInventory().getArmorContents();
+            set.armor = new ItemStack[4];
+            for (int i = 0; i < 4; i++) {
+                ItemStack piece = armor[i] == null ? null : armor[i].clone();
+                assignId(piece);
+                set.armor[i] = piece;
+            }
+            player.sendMessage(ChatColor.GREEN + "Saved armor to " + set.name);
+            return;
+        }
+        long last = lastSwitch.getOrDefault(player.getUniqueId(), 0L);
+        if (System.currentTimeMillis() - last < 2000) {
+            player.sendMessage(ChatColor.RED + "You must wait before switching sets again.");
+            return;
+        }
+        if (set.armor == null) {
+            player.sendMessage(ChatColor.RED + "This set is empty.");
+            return;
+        }
+        player.getInventory().setArmorContents(Arrays.stream(set.armor).map(i -> i == null ? null : i.clone()).toArray(ItemStack[]::new));
+        lastSwitch.put(player.getUniqueId(), System.currentTimeMillis());
+        player.sendMessage(ChatColor.GREEN + "Equipped " + set.name);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent e) {
+        if (!ChatColor.BLUE + "Wardrobe".equals(e.getView().getTitle())) return;
+        // nothing to do
+    }
+
+    private static class SetSlot {
+        final String name;
+        ItemStack[] armor;
+
+        SetSlot(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,11 +10,14 @@ commands:
     description: Open the slayer menu
     usage: /<command>
   armor:
-    description: Open the custom armor menu
+    description: Open the wardrobe
     usage: /<command>
   ah:
     description: Open the auction house
     usage: /<command>
   ahsell:
-    description: List the held item in the auction house
+    description: List the held item for sale
+    usage: /<command> <price>
+  givemorph:
+    description: Give the Morph set items
     usage: /<command>


### PR DESCRIPTION
## Summary
- persist auction house listings under `plugins/CustomItemSystem/save/auctionhouse.yml`
- use action bar API with `ChatMessageType` for mana updates
- show full set bonuses and piece progress in Morph set item lore
- insert blank lines before auction house price and seller info
- save auction data on plugin disable

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684037f6ba60832980a9473c10efe151